### PR TITLE
feat: Add GitHub Actions for label management

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,12 @@
+# CODEOWNERS file indicates code owners for certain files
+#
+# Code owners will automatically be added as a reviewer for PRs that touch
+# the owned files.
+#
+
+# Default owners for everything in the repo
+#
+# Unless a later match takes precedence, these owners will be requested for
+# review when someone opens a pull request.
+
+* @Excoriate

--- a/.github/auto-comment.yml
+++ b/.github/auto-comment.yml
@@ -1,0 +1,18 @@
+---
+pullRequestOpened: |
+    :wave: Thanks for creating a PR!
+
+    Before we can merge this PR, please make sure that all the following items have been
+    checked off. If any of the checklist items are not applicable, please leave them but
+    write a little note why.
+
+    - [ ] Wrote tests
+    - [ ] Check the CONTRIBUTING guide for other ways to contribute
+    - [ ] Linked to Github issue with discussion and accepted design OR link to spec that
+          describes this work.
+    - [ ] Updated relevant documentation (`docs/`) and code comments
+    - [ ] Re-reviewed `Files changed` in the Github PR explorer
+    - [ ] Applied Appropriate Labels
+
+
+    Thank you for your contribution! :rocket:

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,15 @@
+---
+# Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
+# Comment to be posted to on first time issues
+newIssueWelcomeComment: >
+    Thanks for opening your first issue here! 👍 Be sure to follow the issue template.
+
+# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
+# Comment to be posted to on PRs from first time contributors in your repository
+newPRWelcomeComment: >
+    Thanks for opening this pull request! 👍 Please check out our contributing guidelines.
+
+# Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: >
+    Congrats on merging your first pull request! 🎉 We here at `Create Go App` are proud of you.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+---
+version: 2
+updates:
+    - package-ecosystem: gomod
+      directory: /
+      schedule:
+          interval: daily
+          time: 11:00
+      open-pull-requests-limit: 10
+      ignore:
+          - dependency-name: github.com/pterm/pterm
+          - dependency-name: github.com/spf13/cobra

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,30 @@
+---
+ci/cd:
+    - .github/workflows/*
+infrastructure:
+    - terraform/**
+    - infra/**
+    - modules/**
+    - terragrunt/**
+documentation:
+    - README.md
+    - .github/ISSUE_TEMPLATE/*
+    - ./*.md
+patch:
+    - TaskFile.yml
+    - LICENSE
+    - .github/labeler.yml
+    - .yamllint.yml
+    - .Makefile
+    - .pre-commit-config.yaml
+    - .goreleaser.yml
+    - .github/settings.yml
+    - .github/dependabot.yml
+    - .gitignore
+    - .gitattributes
+    - .shellcheckrc
+    - .editorconfig
+    - .dockerignore
+minor:
+    - pkg/*
+    - cli/*

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,14 @@
+---
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 30
+# Label requiring a response
+responseRequiredLabel: more-information-needed
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >-
+    This issue has been automatically closed because there has been no response
+    to our request for more information from the original author. With only the
+    information that is currently in the issue, we don't have enough information
+    to take action. Please feel free to reach out if you have or find the answers we need so
+    that we can investigate further. Thank you!

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,51 @@
+---
+repository:
+    name: daggerx
+    description: DaggerX is a Go package 📦 that helps you avoid DRY while developing Dagger modules.
+    topics: example, devops, tooling, ecs, sre, cli
+    default_branch: main
+    allow_squash_merge: true
+    allow_merge_commit: true
+    allow_rebase_merge: true
+    delete_branch_on_merge: true
+    has_projects: true
+    has_wiki: false
+    enable_vulnerability_alerts: true
+    enable_automated_security_fixes: true
+    teams:
+        - name: maintainers
+          permission: admin
+        - name: contributors
+          permission: push
+labels:
+    - name: bug
+      color: CC0000
+      description: Something is not working fine 🐛.
+    - name: feature
+      color: '#336699'
+      description: New functionality 🚀.
+    - name: Help Wanted
+      new_name: help wanted 🙏
+    - name: documentation
+      color: 0075ca
+      description: Improvements or additions to documentation 📚.
+branches:
+    - name: main
+      protection:
+          required_pull_request_reviews:
+              required_approving_review_count: 1
+              dismiss_stale_reviews: true
+              require_code_owner_reviews: true
+              dismissal_restrictions: {}
+              code_owner_approval: true
+              required_conversation_resolution: true
+          required_status_checks:
+              strict: true
+              contexts:
+                  - DCO
+          enforce_admins: false
+          required_linear_history: true
+          restrictions:
+              users: [Excoriate]
+              apps: []
+              teams: []

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,22 @@
+---
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 10
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 3
+# Issues with these labels will never be considered stale
+exemptLabels:
+    - pinned
+    - security
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+    👋  Hello. Is this still relevant? If so, what is blocking it? Is there anything you can do to help move it forward?
+
+    > This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.
+
+    Thank you for your contributions.
+
+# Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
+closeComment: >
+    ⚡️ This issue has been automatically closed because it has not had recent activity.

--- a/.github/workflows/go-ci-lint.yaml
+++ b/.github/workflows/go-ci-lint.yaml
@@ -1,0 +1,28 @@
+---
+name: Go Linter
+on:
+    workflow_dispatch:
+    push:
+    pull_request:
+permissions:
+    contents: read
+    pull-requests: read
+jobs:
+    golangci:
+        name: Golangci-lint
+        runs-on: ubuntu-latest
+        env:
+            GO_VERSION: ~1.22
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version: ${{ env.GO_VERSION }}
+                  cache: false
+            - name: golangci-lint
+              uses: golangci/golangci-lint-action@v3
+              with:
+                  version: v1.54
+                  args: --config .golangci.yml
+                  github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-ci-tests.yml
+++ b/.github/workflows/go-ci-tests.yml
@@ -1,0 +1,21 @@
+---
+name: Go Tests
+on:
+    workflow_dispatch:
+    push:
+    pull_request:
+env:
+    GO_VERSION: ~1.22
+jobs:
+    golangci:
+        name: Go Tests
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Set up Go
+              uses: actions/setup-go@v4
+              with:
+                  go-version: ${{ env.GO_VERSION }}
+            - name: Test
+              working-directory: ${{ github.workspace }}
+              run: go test -v ./...

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -1,0 +1,47 @@
+---
+name: Remove outdated labels
+on:
+    pull_request_target:
+        types:
+            - closed
+    issues:
+        types:
+            - closed
+jobs:
+    remove-merged-pr-labels:
+        name: Remove merged pull request labels
+        if: github.event.pull_request.merged
+        runs-on: ubuntu-latest
+        steps:
+            - uses: mondeja/remove-labels-gh-action@v1
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  labels: |
+                      awaiting reply
+                      changes requested
+                      duplicate
+                      in discussion
+                      invalid
+                      out of scope
+                      pending
+                      won't add
+    remove-closed-pr-labels:
+        name: Remove closed pull request labels
+        if: github.event_name == 'pull_request_target' && (! github.event.pull_request.merged)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: mondeja/remove-labels-gh-action@v1
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  labels: in discussion
+    remove-closed-issue-labels:
+        name: Remove closed issue labels
+        if: github.event.issue.state == 'closed'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: mondeja/remove-labels-gh-action@v1
+              with:
+                  token: ${{ secrets.GITHUB_TOKEN }}
+                  labels: |
+                      in discussion
+                      pending

--- a/.github/workflows/labels-assigner.yml
+++ b/.github/workflows/labels-assigner.yml
@@ -1,0 +1,31 @@
+---
+name: Assign labels on PR
+on:
+    pull_request:
+        types: [opened, labeled, unlabeled, synchronize]
+defaults:
+    run:
+        shell: bash
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/labeler@v3
+              with:
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
+    size-label:
+        runs-on: ubuntu-latest
+        steps:
+            - name: size-label
+              uses: pascalgn/size-label-action@v0.4.3
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  sizes: >
+                      {
+                        "0": "XS",
+                        "15": "S",
+                        "30": "M",
+                        "50": "L",
+                        "250": "Too Large"
+                      }

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -1,0 +1,27 @@
+---
+name: Lock Threads
+on:
+    schedule:
+        - cron: 50 1 * * *
+jobs:
+    lock:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: dessant/lock-threads@v4
+              with:
+                  github-token: ${{ github.token }}
+                  issue-lock-comment: >
+                      I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+                      If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture
+                      all the details necessary to investigate further.
+
+                  issue-lock-inactive-days: '30'
+                  pr-lock-comment: >
+                      I'm going to lock this pull request because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active
+                      contributions.
+
+                      If you have found a problem that seems related to this change, please open a new issue and complete the issue template so we can capture
+                      all the details necessary to investigate further.
+
+                  pr-lock-inactive-days: '30'

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,32 @@
+---
+name: Check Markdown links
+on:
+    workflow_dispatch:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches: [main]
+jobs:
+    markdown-link-check-on-pull-request:
+        if: github.event_name == 'pull_request'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: technote-space/get-diff-action@v6
+              with:
+                  PATTERNS: |
+                      **/**.md
+            - uses: gaurav-nelson/github-action-markdown-link-check@v1
+              with:
+                  check-modified-files-only: yes
+                  config-file: .md-link-check.json
+              if: env.GIT_DIFF
+    markdown-link-check-on-push-or-workflow_dispatch:
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - uses: gaurav-nelson/github-action-markdown-link-check@v1
+              with:
+                  config-file: .markdown-link-check.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+---
+name: Release
+on:
+    push:
+        branches:
+            - main
+            - '[0-9]+.[0-9]+.x'
+    workflow_dispatch:
+defaults:
+    run:
+        shell: bash
+jobs:
+    release-please:
+        permissions:
+            contents: write
+            pull-requests: write
+        runs-on: ubuntu-latest
+        outputs:
+            releases_created: ${{ steps.release.outputs.releases_created }}
+            tag_name: ${{ steps.release.outputs.tag_name }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3
+            - uses: google-github-actions/release-please-action@ee9822ec2c397e8a364d634464339ac43a06e042
+              id: release
+              with:
+                  command: manifest
+                  token: ${{secrets.GITHUB_TOKEN}}
+                  default-branch: main

--- a/.github/workflows/semantic-pr.yaml
+++ b/.github/workflows/semantic-pr.yaml
@@ -1,0 +1,59 @@
+---
+name: Semantic PR Validation
+on:
+    pull_request_target:
+        types:
+            - opened
+            - edited
+            - synchronize
+defaults:
+    run:
+        shell: bash
+jobs:
+    validate:
+        runs-on: ubuntu-22.04
+        permissions:
+            contents: read # Needed for checking out the repository
+            pull-requests: read # Needed for reading prs
+        steps:
+            - name: Validate Pull Request
+              uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # v5.2.0
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+          # Configure which types are allowed.
+          # Default: https://github.com/commitizen/conventional-commit-types
+                  types: |
+                      feat
+                      fix
+                      build
+                      chore
+                      ci
+                      docs
+                      perf
+                      refactor
+                      revert
+                      style
+                      test
+                      deps
+                  scopes: |
+                      deps
+          # Configure that a scope must always be provided.
+                  requireScope: false
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+                  validateSingleCommit: true
+          # yamllint disable-line rule:comments-indentation
+          # Configure additional validation for the subject based on a regex.
+
+          # This ensures the subject doesn't start with an uppercase character.
+                  subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+                  subjectPatternError: |-
+                      The subject "{subject}" found in the pull request title "{title}"
+                      didn't match the configured pattern. Please ensure that the subject
+                      doesn't start with an uppercase character.

--- a/.github/workflows/yaml-linter.yml
+++ b/.github/workflows/yaml-linter.yml
@@ -1,0 +1,35 @@
+---
+name: Yaml Linter
+on:
+    workflow_dispatch:
+    push:
+    pull_request:
+jobs:
+    yamllint:
+        name: Yamllint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v3
+            - name: Lint Workflows
+              uses: karancode/yamllint-github-action@v2.1.1
+              with:
+                  yamllint_config_filepath: .yamllint.yml
+                  yamllint_file_or_dir: .github/workflows
+                  yamllint_comment: 'true'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Lint GitHub config yamls
+              uses: karancode/yamllint-github-action@v2.1.1
+              with:
+                  yamllint_config_filepath: .yamllint.yml
+                  yamllint_file_or_dir: .github
+                  yamllint_comment: 'true'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            - name: Lint yaml files in root dir
+              uses: karancode/yamllint-github-action@v2.1.1
+              with:
+                  yamllint_config_filepath: .yamllint.yml
+                  yamllint_comment: 'true'
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Added workflows to automatically remove outdated labels on closed PRs and issues.
- Included a configuration file for Probot No Response plugin to assist in issue closure.
- Implemented a workflow to check markdown links on push or pull request events.
- Setup a job to lock inactive threads after 30 days of closure for better issue management.
- Created a workflow to assign labels to PRs based on specific criteria.