### PR TITLE
feat: Extend ApkoBuilder with additional configuration options

### DIFF
--- a/pkg/builderx/apko.go
+++ b/pkg/builderx/apko.go
@@ -1,0 +1,252 @@
+package builderx
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// ApkoBuilder represents a builder for APKO commands
+type ApkoBuilder struct {
+	configFile             string
+	outputImage            string
+	outputTarball          string
+	keyringPaths           []string
+	architectures          []string
+	cacheDir               string
+	extraArgs              []string
+	wolfiKeyring           bool
+	alpineKeyring          bool
+	buildArch              string
+	buildContext           string
+	debug                  bool
+	keyringAppendPlaintext []string
+	noNetwork              bool
+	repositoryAppend       []string
+	timestamp              string
+}
+
+// NewApkoBuilder creates a new ApkoBuilder with default settings.
+// It initializes the ApkoBuilder with default architectures "x86_64" and "aarch64".
+func NewApkoBuilder() *ApkoBuilder {
+	return &ApkoBuilder{
+		architectures: []string{"x86_64", "aarch64"}, // Default architectures
+	}
+}
+
+// WithConfigFile sets the configuration file for the APKO build.
+// It takes a string parameter 'configFile' which is the path to the configuration file.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithConfigFile(configFile string) *ApkoBuilder {
+	b.configFile = configFile
+	return b
+}
+
+// WithOutputImage sets the output image name for the APKO build.
+// It takes a string parameter 'outputImage' which is the name of the output image.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithOutputImage(outputImage string) *ApkoBuilder {
+	b.outputImage = outputImage
+	return b
+}
+
+// WithOutputTarball sets the output tarball path for the APKO build.
+// It takes a string parameter 'outputTarball' which is the path to the output tarball.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithOutputTarball(outputTarball string) *ApkoBuilder {
+	b.outputTarball = outputTarball
+	return b
+}
+
+// WithKeyring adds a keyring path to the APKO build.
+// It takes a string parameter 'keyringPath' which is the path to the keyring file.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithKeyring(keyringPath string) *ApkoBuilder {
+	b.keyringPaths = append(b.keyringPaths, keyringPath)
+	return b
+}
+
+// WithWolfiKeyring adds the Wolfi keyring to the APKO build.
+// It sets the wolfiKeyring field to true.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithWolfiKeyring() *ApkoBuilder {
+	b.wolfiKeyring = true
+	return b
+}
+
+// WithAlpineKeyring adds the Alpine keyring to the APKO build.
+// It sets the alpineKeyring field to true.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithAlpineKeyring() *ApkoBuilder {
+	b.alpineKeyring = true
+	return b
+}
+
+// WithArchitecture adds an architecture to the APKO build.
+// It takes a string parameter 'arch' which is the architecture to be added.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithArchitecture(arch string) *ApkoBuilder {
+	b.architectures = append(b.architectures, arch)
+	return b
+}
+
+// WithCacheDir sets the cache directory for the APKO build.
+// It takes a string parameter 'cacheDir' which is the path to the cache directory.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithCacheDir(cacheDir string) *ApkoBuilder {
+	b.cacheDir = cacheDir
+	return b
+}
+
+// WithExtraArg adds an extra argument to the APKO build command.
+// It takes a string parameter 'arg' which is the extra argument to be added.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithExtraArg(arg string) *ApkoBuilder {
+	b.extraArgs = append(b.extraArgs, arg)
+	return b
+}
+
+// WithBuildArch sets the build architecture
+func (b *ApkoBuilder) WithBuildArch(arch string) *ApkoBuilder {
+	b.buildArch = arch
+	return b
+}
+
+// WithBuildContext sets the build context directory
+func (b *ApkoBuilder) WithBuildContext(dir string) *ApkoBuilder {
+	b.buildContext = dir
+	return b
+}
+
+// WithDebug enables debug output
+func (b *ApkoBuilder) WithDebug() *ApkoBuilder {
+	b.debug = true
+	return b
+}
+
+// WithKeyringAppendPlaintext appends a plaintext keyring
+func (b *ApkoBuilder) WithKeyringAppendPlaintext(keyring string) *ApkoBuilder {
+	b.keyringAppendPlaintext = append(b.keyringAppendPlaintext, keyring)
+	return b
+}
+
+// WithNoNetwork disables network access during the build
+func (b *ApkoBuilder) WithNoNetwork() *ApkoBuilder {
+	b.noNetwork = true
+	return b
+}
+
+// WithRepositoryAppend appends a repository to use for the build
+func (b *ApkoBuilder) WithRepositoryAppend(repo string) *ApkoBuilder {
+	b.repositoryAppend = append(b.repositoryAppend, repo)
+	return b
+}
+
+// WithTimestamp sets the timestamp for the build
+func (b *ApkoBuilder) WithTimestamp(timestamp string) *ApkoBuilder {
+	b.timestamp = timestamp
+	return b
+}
+
+// BuildCommand generates the APKO build command based on the current configuration of the ApkoBuilder.
+// It returns a slice of strings representing the command and an error if any required fields are missing.
+func (b *ApkoBuilder) BuildCommand() ([]string, error) {
+	if b.configFile == "" {
+		return nil, fmt.Errorf("config file is required")
+	}
+
+	if b.outputImage == "" {
+		return nil, fmt.Errorf("output image name is required")
+	}
+
+	cmd := []string{"apko", "build"}
+
+	for _, keyring := range b.keyringPaths {
+		cmd = append(cmd, "--keyring-append", keyring)
+	}
+
+	if b.wolfiKeyring {
+		cmd = append(cmd, "--keyring-append", "/etc/apk/keys/wolfi-signing.rsa.pub")
+	}
+
+	if b.alpineKeyring {
+		cmd = append(cmd, "--keyring-append", "/etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub")
+	}
+
+	for _, arch := range b.architectures {
+		cmd = append(cmd, "--arch", arch)
+	}
+
+	if b.cacheDir != "" {
+		cmd = append(cmd, "--cache-dir", b.cacheDir)
+	}
+
+	if b.buildArch != "" {
+		cmd = append(cmd, "--build-arch", b.buildArch)
+	}
+
+	if b.buildContext != "" {
+		cmd = append(cmd, "--build-context", b.buildContext)
+	}
+
+	if b.debug {
+		cmd = append(cmd, "--debug")
+	}
+
+	for _, keyring := range b.keyringAppendPlaintext {
+		cmd = append(cmd, "--keyring-append-plaintext", keyring)
+	}
+
+	if b.noNetwork {
+		cmd = append(cmd, "--no-network")
+	}
+
+	for _, repo := range b.repositoryAppend {
+		cmd = append(cmd, "--repository-append", repo)
+	}
+
+	if b.timestamp != "" {
+		cmd = append(cmd, "--timestamp", b.timestamp)
+	}
+
+	cmd = append(cmd, b.configFile, b.outputImage)
+
+	if b.outputTarball != "" {
+		cmd = append(cmd, b.outputTarball)
+	}
+
+	cmd = append(cmd, b.extraArgs...)
+
+	return cmd, nil
+}
+
+// GetKeyringInfo returns the keyring information based on the preset.
+// It takes a string parameter 'preset' which specifies the keyring preset ("alpine" or "wolfi").
+// It returns the key URL, key path, and an error if the preset is unsupported.
+func GetKeyringInfo(preset string) (keyURL, keyPath string, err error) {
+	switch preset {
+	case "alpine":
+		return "https://alpinelinux.org/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+			"/etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+			nil
+	case "wolfi":
+		return "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+			"/etc/apk/keys/wolfi-signing.rsa.pub",
+			nil
+	default:
+		return "", "", fmt.Errorf("unsupported preset: %s", preset)
+	}
+}
+
+// GetCacheDir returns the APKO cache directory path.
+// It takes a string parameter 'mntPrefix' which is the mount prefix.
+// It returns the full path to the cache directory.
+func GetCacheDir(mntPrefix string) string {
+	return filepath.Join(mntPrefix, "var", "cache", "apko")
+}
+
+// GetOutputTarPath returns the APKO output tar file path.
+// It takes a string parameter 'mntPrefix' which is the mount prefix.
+// It returns the full path to the output tar file.
+func GetOutputTarPath(mntPrefix string) string {
+	return filepath.Join(mntPrefix, "image.tar")
+}

--- a/pkg/builderx/apko_test.go
+++ b/pkg/builderx/apko_test.go
@@ -1,0 +1,264 @@
+package builderx
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApkoBuilder(t *testing.T) {
+	t.Run("NewApkoBuilder", func(t *testing.T) {
+		builder := NewApkoBuilder()
+		if builder == nil {
+			t.Fatal("NewApkoBuilder returned nil")
+		}
+		if !reflect.DeepEqual(builder.architectures, []string{"x86_64", "aarch64"}) {
+			t.Errorf("Default architectures not set correctly, got %v", builder.architectures)
+		}
+	})
+
+	t.Run("WithConfigFile", func(t *testing.T) {
+		builder := NewApkoBuilder().WithConfigFile("config.yaml")
+		if builder.configFile != "config.yaml" {
+			t.Errorf("Config file not set correctly, got %s", builder.configFile)
+		}
+	})
+
+	t.Run("WithOutputImage", func(t *testing.T) {
+		builder := NewApkoBuilder().WithOutputImage("my-image:latest")
+		if builder.outputImage != "my-image:latest" {
+			t.Errorf("Output image not set correctly, got %s", builder.outputImage)
+		}
+	})
+
+	t.Run("WithOutputTarball", func(t *testing.T) {
+		builder := NewApkoBuilder().WithOutputTarball("image.tar")
+		if builder.outputTarball != "image.tar" {
+			t.Errorf("Output tarball not set correctly, got %s", builder.outputTarball)
+		}
+	})
+
+	t.Run("WithKeyring", func(t *testing.T) {
+		builder := NewApkoBuilder().WithKeyring("/path/to/keyring.pub")
+		if !reflect.DeepEqual(builder.keyringPaths, []string{"/path/to/keyring.pub"}) {
+			t.Errorf("Keyring path not set correctly, got %v", builder.keyringPaths)
+		}
+	})
+
+	t.Run("WithWolfiKeyring", func(t *testing.T) {
+		builder := NewApkoBuilder().WithWolfiKeyring()
+		if !builder.wolfiKeyring {
+			t.Error("Wolfi keyring not enabled")
+		}
+	})
+
+	t.Run("WithAlpineKeyring", func(t *testing.T) {
+		builder := NewApkoBuilder().WithAlpineKeyring()
+		if !builder.alpineKeyring {
+			t.Error("Alpine keyring not enabled")
+		}
+	})
+
+	t.Run("WithArchitecture", func(t *testing.T) {
+		builder := NewApkoBuilder().WithArchitecture("arm64")
+		if !reflect.DeepEqual(builder.architectures, []string{"x86_64", "aarch64", "arm64"}) {
+			t.Errorf("Architecture not added correctly, got %v", builder.architectures)
+		}
+	})
+
+	t.Run("WithCacheDir", func(t *testing.T) {
+		builder := NewApkoBuilder().WithCacheDir("/tmp/cache")
+		if builder.cacheDir != "/tmp/cache" {
+			t.Errorf("Cache directory not set correctly, got %s", builder.cacheDir)
+		}
+	})
+
+	t.Run("WithExtraArg", func(t *testing.T) {
+		builder := NewApkoBuilder().WithExtraArg("--debug")
+		if !reflect.DeepEqual(builder.extraArgs, []string{"--debug"}) {
+			t.Errorf("Extra argument not added correctly, got %v", builder.extraArgs)
+		}
+	})
+
+	t.Run("WithBuildArch", func(t *testing.T) {
+		builder := NewApkoBuilder().WithBuildArch("amd64")
+		if builder.buildArch != "amd64" {
+			t.Errorf("Build arch not set correctly, got %s", builder.buildArch)
+		}
+	})
+
+	t.Run("WithBuildContext", func(t *testing.T) {
+		builder := NewApkoBuilder().WithBuildContext("/path/to/context")
+		if builder.buildContext != "/path/to/context" {
+			t.Errorf("Build context not set correctly, got %s", builder.buildContext)
+		}
+	})
+
+	t.Run("WithDebug", func(t *testing.T) {
+		builder := NewApkoBuilder().WithDebug()
+		if !builder.debug {
+			t.Error("Debug not enabled")
+		}
+	})
+
+	t.Run("WithKeyringAppendPlaintext", func(t *testing.T) {
+		builder := NewApkoBuilder().WithKeyringAppendPlaintext("/path/to/plaintext.key")
+		if !reflect.DeepEqual(builder.keyringAppendPlaintext, []string{"/path/to/plaintext.key"}) {
+			t.Errorf("Plaintext keyring not set correctly, got %v", builder.keyringAppendPlaintext)
+		}
+	})
+
+	t.Run("WithNoNetwork", func(t *testing.T) {
+		builder := NewApkoBuilder().WithNoNetwork()
+		if !builder.noNetwork {
+			t.Error("No network option not enabled")
+		}
+	})
+
+	t.Run("WithRepositoryAppend", func(t *testing.T) {
+		builder := NewApkoBuilder().WithRepositoryAppend("https://example.com/repo")
+		if !reflect.DeepEqual(builder.repositoryAppend, []string{"https://example.com/repo"}) {
+			t.Errorf("Repository append not set correctly, got %v", builder.repositoryAppend)
+		}
+	})
+
+	t.Run("WithTimestamp", func(t *testing.T) {
+		builder := NewApkoBuilder().WithTimestamp("2023-01-01T00:00:00Z")
+		if builder.timestamp != "2023-01-01T00:00:00Z" {
+			t.Errorf("Timestamp not set correctly, got %s", builder.timestamp)
+		}
+	})
+
+	t.Run("BuildCommand", func(t *testing.T) {
+		builder := NewApkoBuilder().
+			WithConfigFile("config.yaml").
+			WithOutputImage("my-image:latest").
+			WithOutputTarball("image.tar").
+			WithKeyring("/custom/keyring.pub").
+			WithWolfiKeyring().
+			WithAlpineKeyring().
+			WithArchitecture("arm64").
+			WithCacheDir("/tmp/cache").
+			WithExtraArg("--custom-arg").
+			WithBuildArch("amd64").
+			WithBuildContext("/build/context").
+			WithDebug().
+			WithKeyringAppendPlaintext("/plaintext.key").
+			WithNoNetwork().
+			WithRepositoryAppend("https://example.com/repo").
+			WithTimestamp("2023-01-01T00:00:00Z")
+
+		expected := []string{
+			"apko", "build",
+			"--keyring-append", "/custom/keyring.pub",
+			"--keyring-append", "/etc/apk/keys/wolfi-signing.rsa.pub",
+			"--keyring-append", "/etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+			"--arch", "x86_64",
+			"--arch", "aarch64",
+			"--arch", "arm64",
+			"--cache-dir", "/tmp/cache",
+			"--build-arch", "amd64",
+			"--build-context", "/build/context",
+			"--debug",
+			"--keyring-append-plaintext", "/plaintext.key",
+			"--no-network",
+			"--repository-append", "https://example.com/repo",
+			"--timestamp", "2023-01-01T00:00:00Z",
+			"config.yaml",
+			"my-image:latest",
+			"image.tar",
+			"--custom-arg",
+		}
+
+		cmd, err := builder.BuildCommand()
+		if err != nil {
+			t.Fatalf("BuildCommand returned an error: %v", err)
+		}
+
+		if !reflect.DeepEqual(cmd, expected) {
+			t.Errorf("BuildCommand did not return expected command. Got: %v, Want: %v", cmd, expected)
+		}
+	})
+
+	t.Run("BuildCommand_MissingConfigFile", func(t *testing.T) {
+		builder := NewApkoBuilder().WithOutputImage("my-image:latest")
+		_, err := builder.BuildCommand()
+		if err == nil || err.Error() != "config file is required" {
+			t.Errorf("Expected error for missing config file, got: %v", err)
+		}
+	})
+
+	t.Run("BuildCommand_MissingOutputImage", func(t *testing.T) {
+		builder := NewApkoBuilder().WithConfigFile("config.yaml")
+		_, err := builder.BuildCommand()
+		if err == nil || err.Error() != "output image name is required" {
+			t.Errorf("Expected error for missing output image, got: %v", err)
+		}
+	})
+}
+
+func TestGetKeyringInfo(t *testing.T) {
+	testCases := []struct {
+		name          string
+		preset        string
+		expectedURL   string
+		expectedPath  string
+		expectedError bool
+	}{
+		{
+			name:         "Alpine Preset",
+			preset:       "alpine",
+			expectedURL:  "https://alpinelinux.org/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+			expectedPath: "/etc/apk/keys/alpine-devel@lists.alpinelinux.org-4a6a0840.rsa.pub",
+		},
+		{
+			name:         "Wolfi Preset",
+			preset:       "wolfi",
+			expectedURL:  "https://packages.wolfi.dev/os/wolfi-signing.rsa.pub",
+			expectedPath: "/etc/apk/keys/wolfi-signing.rsa.pub",
+		},
+		{
+			name:          "Unsupported Preset",
+			preset:        "unsupported",
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			url, path, err := GetKeyringInfo(tc.preset)
+			if tc.expectedError {
+				if err == nil {
+					t.Error("Expected an error, but got nil")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if url != tc.expectedURL {
+					t.Errorf("Expected URL %s, got %s", tc.expectedURL, url)
+				}
+				if path != tc.expectedPath {
+					t.Errorf("Expected path %s, got %s", tc.expectedPath, path)
+				}
+			}
+		})
+	}
+}
+
+func TestGetCacheDir(t *testing.T) {
+	mntPrefix := "/mnt"
+	expected := "/mnt/var/cache/apko"
+	result := GetCacheDir(mntPrefix)
+	if result != expected {
+		t.Errorf("Expected cache dir %s, got %s", expected, result)
+	}
+}
+
+func TestGetOutputTarPath(t *testing.T) {
+	mntPrefix := "/mnt"
+	expected := "/mnt/image.tar"
+	result := GetOutputTarPath(mntPrefix)
+	if result != expected {
+		t.Errorf("Expected output tar path %s, got %s", expected, result)
+	}
+}


### PR DESCRIPTION
- Add support for configuring the Apko builder with various options:
  - `WithConfigFile`: Set the path to the Apko configuration file
  - `WithOutputImage`: Set the output image name
  - `WithOutputTarball`: Set the output tarball name
  - `WithKeyring`: Add a custom keyring path
  - `WithWolfiKeyring`: Enable the Wolfi keyring
  - `WithAlpineKeyring`: Enable the Alpine keyring
  - `WithArchitecture`: Add an additional architecture to the build
  - `WithCacheDir`: Set the cache directory
  - `WithExtraArg`: Add an extra argument to the Apko command
  - `WithBuildArch`: Set the build architecture
  - `WithBuildContext`: Set the build context directory
  - `WithDebug`: Enable debug mode
  - `WithKeyringAppendPlaintext`: Add a plaintext keyring file
  - `WithNoNetwork`: Disable network access during the build
  - `WithRepositoryAppend`: Add an additional repository to the build
  - `WithTimestamp`: Set a custom timestamp for the build