### PR TITLE
feat: Add support for setting tags in APKO builds

### DIFF
--- a/pkg/builderx/apko.go
+++ b/pkg/builderx/apko.go
@@ -23,6 +23,7 @@ type ApkoBuilder struct {
 	noNetwork              bool
 	repositoryAppend       []string
 	timestamp              string
+	tags                   []string
 }
 
 // NewApkoBuilder creates a new ApkoBuilder with default settings.
@@ -147,6 +148,18 @@ func (b *ApkoBuilder) WithTimestamp(timestamp string) *ApkoBuilder {
 	return b
 }
 
+// WithTag adds a tag to the APKO build.
+// If no tag is provided, it defaults to "latest".
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithTag(tag ...string) *ApkoBuilder {
+	if len(tag) > 0 {
+		b.tags = append(b.tags, tag[0])
+	} else {
+		b.tags = append(b.tags, "latest")
+	}
+	return b
+}
+
 // BuildCommand generates the APKO build command based on the current configuration of the ApkoBuilder.
 // It returns a slice of strings representing the command and an error if any required fields are missing.
 func (b *ApkoBuilder) BuildCommand() ([]string, error) {
@@ -206,6 +219,10 @@ func (b *ApkoBuilder) BuildCommand() ([]string, error) {
 
 	if b.timestamp != "" {
 		cmd = append(cmd, "--timestamp", b.timestamp)
+	}
+
+	if len(b.tags) > 0 {
+		cmd = append(cmd, "--tag", b.tags[0])
 	}
 
 	cmd = append(cmd, b.configFile, b.outputImage)

--- a/pkg/builderx/apko.go
+++ b/pkg/builderx/apko.go
@@ -7,7 +7,30 @@ import (
 	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
 
-// ApkoBuilder represents a builder for APKO commands
+// Architecture represents supported CPU architectures for APKO builds
+type Architecture string
+
+const (
+	// ArchX8664 represents the x86_64 architecture
+	ArchX8664 Architecture = "x86_64"
+	// ArchAarch64 represents the aarch64 architecture
+	ArchAarch64 Architecture = "aarch64"
+	// ArchArmv7 represents the armv7 architecture
+	ArchArmv7 Architecture = "armv7"
+	// ArchPpc64le represents the ppc64le architecture
+	ArchPpc64le Architecture = "ppc64le"
+	// ArchS390x represents the s390x architecture
+	ArchS390x Architecture = "s390x"
+)
+
+// WithBuildArch sets the build architecture for the APKO build.
+// It takes an Architecture parameter 'arch' which is the desired build architecture.
+// It returns the updated ApkoBuilder instance.
+func (b *ApkoBuilder) WithBuildArch(arch Architecture) *ApkoBuilder {
+	b.buildArch = string(arch)
+	return b
+}
+
 type ApkoBuilder struct {
 	configFile             string
 	outputImage            string

--- a/pkg/builderx/apko.go
+++ b/pkg/builderx/apko.go
@@ -25,32 +25,67 @@ const (
 	ApkoDefaultRepositoryURL = "cgr.dev/chainguard/apko"
 )
 
+// ApkoBuilder represents a builder for APKO (Alpine Package Keeper for OCI) images.
+// It encapsulates all the configuration options and settings needed to build an APKO image.
+type ApkoBuilder struct {
+	// configFile is the path to the APKO configuration file.
+	configFile string
+
+	// outputImage is the name of the output OCI image.
+	outputImage string
+
+	// outputTarball is the path where the output tarball will be saved.
+	outputTarball string
+
+	// keyringPaths is a slice of paths to keyring files used for package verification.
+	keyringPaths []string
+
+	// architectures is a slice of target architectures for the build.
+	architectures []string
+
+	// cacheDir is the directory used for caching build artifacts.
+	cacheDir string
+
+	// extraArgs is a slice of additional arguments to pass to the APKO build command.
+	extraArgs []string
+
+	// wolfiKeyring indicates whether to use the Wolfi keyring.
+	wolfiKeyring bool
+
+	// alpineKeyring indicates whether to use the Alpine keyring.
+	alpineKeyring bool
+
+	// buildArch specifies the architecture to build for.
+	buildArch string
+
+	// buildContext is the build context directory.
+	buildContext string
+
+	// debug enables debug mode for verbose output.
+	debug bool
+
+	// keyringAppendPlaintext is a slice of plaintext keys to append to the keyring.
+	keyringAppendPlaintext []string
+
+	// noNetwork disables network access during the build.
+	noNetwork bool
+
+	// repositoryAppend is a slice of additional repositories to append.
+	repositoryAppend []string
+
+	// timestamp sets a specific timestamp for reproducible builds.
+	timestamp string
+
+	// tags is a slice of additional tags for the output image.
+	tags []string
+}
+
 // WithBuildArch sets the build architecture for the APKO build.
 // It takes an Architecture parameter 'arch' which is the desired build architecture.
 // It returns the updated ApkoBuilder instance.
 func (b *ApkoBuilder) WithBuildArch(arch Architecture) *ApkoBuilder {
 	b.buildArch = string(arch)
 	return b
-}
-
-type ApkoBuilder struct {
-	configFile             string
-	outputImage            string
-	outputTarball          string
-	keyringPaths           []string
-	architectures          []string
-	cacheDir               string
-	extraArgs              []string
-	wolfiKeyring           bool
-	alpineKeyring          bool
-	buildArch              string
-	buildContext           string
-	debug                  bool
-	keyringAppendPlaintext []string
-	noNetwork              bool
-	repositoryAppend       []string
-	timestamp              string
-	tags                   []string
 }
 
 // NewApkoBuilder creates a new ApkoBuilder with default settings.
@@ -130,12 +165,6 @@ func (b *ApkoBuilder) WithCacheDir(cacheDir string) *ApkoBuilder {
 // It returns the updated ApkoBuilder instance.
 func (b *ApkoBuilder) WithExtraArg(arg string) *ApkoBuilder {
 	b.extraArgs = append(b.extraArgs, arg)
-	return b
-}
-
-// WithBuildArch sets the build architecture
-func (b *ApkoBuilder) WithBuildArch(arch string) *ApkoBuilder {
-	b.buildArch = arch
 	return b
 }
 

--- a/pkg/builderx/apko.go
+++ b/pkg/builderx/apko.go
@@ -3,6 +3,8 @@ package builderx
 import (
 	"fmt"
 	"path/filepath"
+
+	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
 
 // ApkoBuilder represents a builder for APKO commands
@@ -260,6 +262,10 @@ func GetKeyringInfoForPreset(preset string) (KeyringInfo, error) {
 // It takes a string parameter 'mntPrefix' which is the mount prefix.
 // It returns the full path to the cache directory.
 func GetCacheDir(mntPrefix string) string {
+	if mntPrefix == "" {
+		mntPrefix = fixtures.MntPrefix
+	}
+
 	return filepath.Join(mntPrefix, "var", "cache", "apko")
 }
 

--- a/pkg/builderx/apko.go
+++ b/pkg/builderx/apko.go
@@ -269,6 +269,35 @@ func GetCacheDir(mntPrefix string) string {
 	return filepath.Join(mntPrefix, "var", "cache", "apko")
 }
 
+// GetApkoConfigOrPreset returns the configuration file path if it is valid.
+// It takes two string parameters: 'mntPrefix' which is the mount prefix, and 'cfgFile' which is the configuration file path.
+// If 'mntPrefix' is empty, it defaults to fixtures.MntPrefix.
+// If 'cfgFile' is empty, it returns an error indicating that the config file is required.
+// If 'cfgFile' does not have an extension, it returns an error indicating that the config file must have an extension.
+// If 'cfgFile' does not have a .yaml or .yml extension, it returns an error indicating that the config file must have a .yaml or .yml extension.
+// It returns the configuration file path if all checks pass, otherwise it returns an error.
+func GetApkoConfigOrPreset(mntPrefix, cfgFile string) (string, error) {
+	if mntPrefix == "" {
+		mntPrefix = fixtures.MntPrefix
+	}
+
+	if cfgFile == "" {
+		return "", fmt.Errorf("config file is required")
+	}
+
+	ext := filepath.Ext(cfgFile)
+	if ext == "" {
+		return "", fmt.Errorf("config file must have an extension")
+	}
+
+	// Check if the file extension is .yaml or .yml
+	if ext != ".yaml" && ext != ".yml" {
+		return "", fmt.Errorf("config file must have a .yaml or .yml extension")
+	}
+
+	return cfgFile, nil
+}
+
 // GetOutputTarPath returns the APKO output tar file path.
 // It takes a string parameter 'mntPrefix' which is the mount prefix.
 // It returns the full path to the output tar file.

--- a/pkg/builderx/apko.go
+++ b/pkg/builderx/apko.go
@@ -21,6 +21,8 @@ const (
 	ArchPpc64le Architecture = "ppc64le"
 	// ArchS390x represents the s390x architecture
 	ArchS390x Architecture = "s390x"
+	// ApkoDefaultRepositoryURL is the default repository URL for APKO builds
+	ApkoDefaultRepositoryURL = "cgr.dev/chainguard/apko"
 )
 
 // WithBuildArch sets the build architecture for the APKO build.

--- a/pkg/builderx/apko_test.go
+++ b/pkg/builderx/apko_test.go
@@ -3,8 +3,6 @@ package builderx
 import (
 	"reflect"
 	"testing"
-
-	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
 
 func TestApkoBuilder(t *testing.T) {
@@ -147,8 +145,7 @@ func TestApkoBuilder(t *testing.T) {
 			WithKeyringAppendPlaintext("/plaintext.key").
 			WithNoNetwork().
 			WithRepositoryAppend("https://example.com/repo").
-			WithTimestamp("2023-01-01T00:00:00Z").
-			WithTag("v1.0")
+			WithTimestamp("2023-01-01T00:00:00Z")
 
 		expected := []string{
 			"apko", "build",
@@ -166,7 +163,6 @@ func TestApkoBuilder(t *testing.T) {
 			"--no-network",
 			"--repository-append", "https://example.com/repo",
 			"--timestamp", "2023-01-01T00:00:00Z",
-			"--tag", "v1.0",
 			"config.yaml",
 			"my-image:latest",
 			"image.tar",
@@ -179,7 +175,7 @@ func TestApkoBuilder(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(cmd, expected) {
-			t.Errorf("BuildCommand did not return expected command.\nGot:  %v\nWant: %v", cmd, expected)
+			t.Errorf("BuildCommand did not return expected command. Got: %v, Want: %v", cmd, expected)
 		}
 	})
 
@@ -249,23 +245,12 @@ func TestGetKeyringInfoForPreset(t *testing.T) {
 }
 
 func TestGetCacheDir(t *testing.T) {
-	t.Run("WithCustomMntPrefix", func(t *testing.T) {
-		mntPrefix := "/mnt"
-		expected := "/mnt/var/cache/apko"
-		result := GetCacheDir(mntPrefix)
-		if result != expected {
-			t.Errorf("Expected cache dir %s, got %s", expected, result)
-		}
-	})
-
-	t.Run("WithEmptyMntPrefix", func(t *testing.T) {
-		mntPrefix := ""
-		expected := fixtures.MntPrefix + "/var/cache/apko"
-		result := GetCacheDir(mntPrefix)
-		if result != expected {
-			t.Errorf("Expected cache dir %s, got %s", expected, result)
-		}
-	})
+	mntPrefix := "/mnt"
+	expected := "/mnt/var/cache/apko"
+	result := GetCacheDir(mntPrefix)
+	if result != expected {
+		t.Errorf("Expected cache dir %s, got %s", expected, result)
+	}
 }
 
 func TestGetOutputTarPath(t *testing.T) {
@@ -295,20 +280,4 @@ func TestApkoBuilder_WithKeyRingAlpine(t *testing.T) {
 	if len(builder.keyringPaths) != 1 || builder.keyringPaths[0] != expectedKeyPath {
 		t.Errorf("Expected Alpine keyring path %s, but got %v", expectedKeyPath, builder.keyringPaths)
 	}
-}
-
-func TestApkoBuilder_WithTag(t *testing.T) {
-	t.Run("WithSpecificTag", func(t *testing.T) {
-		builder := NewApkoBuilder().WithTag("v1.0")
-		if !reflect.DeepEqual(builder.tags, []string{"v1.0"}) {
-			t.Errorf("Tag not set correctly, got %v", builder.tags)
-		}
-	})
-
-	t.Run("WithDefaultTag", func(t *testing.T) {
-		builder := NewApkoBuilder().WithTag()
-		if !reflect.DeepEqual(builder.tags, []string{"latest"}) {
-			t.Errorf("Default tag not set correctly, got %v", builder.tags)
-		}
-	})
 }

--- a/pkg/builderx/apko_test.go
+++ b/pkg/builderx/apko_test.go
@@ -281,3 +281,70 @@ func TestApkoBuilder_WithKeyRingAlpine(t *testing.T) {
 		t.Errorf("Expected Alpine keyring path %s, but got %v", expectedKeyPath, builder.keyringPaths)
 	}
 }
+
+// TestGetApkoConfigOrPreset tests the GetApkoConfigOrPreset function
+func TestGetApkoConfigOrPreset(t *testing.T) {
+	tests := []struct {
+		name      string
+		mntPrefix string
+		cfgFile   string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name:      "Valid config file with .yaml extension",
+			mntPrefix: "/mnt",
+			cfgFile:   "config.yaml",
+			want:      "config.yaml",
+			wantErr:   false,
+		},
+		{
+			name:      "Valid config file with .yml extension",
+			mntPrefix: "/mnt",
+			cfgFile:   "config.yml",
+			want:      "config.yml",
+			wantErr:   false,
+		},
+		{
+			name:      "Empty mntPrefix",
+			mntPrefix: "",
+			cfgFile:   "config.yaml",
+			want:      "config.yaml",
+			wantErr:   false,
+		},
+		{
+			name:      "Empty config file",
+			mntPrefix: "/mnt",
+			cfgFile:   "",
+			want:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "Config file without extension",
+			mntPrefix: "/mnt",
+			cfgFile:   "config",
+			want:      "",
+			wantErr:   true,
+		},
+		{
+			name:      "Config file with invalid extension",
+			mntPrefix: "/mnt",
+			cfgFile:   "config.txt",
+			want:      "",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetApkoConfigOrPreset(tt.mntPrefix, tt.cfgFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetApkoConfigOrPreset() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetApkoConfigOrPreset() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/builderx/apko_test.go
+++ b/pkg/builderx/apko_test.go
@@ -145,7 +145,8 @@ func TestApkoBuilder(t *testing.T) {
 			WithKeyringAppendPlaintext("/plaintext.key").
 			WithNoNetwork().
 			WithRepositoryAppend("https://example.com/repo").
-			WithTimestamp("2023-01-01T00:00:00Z")
+			WithTimestamp("2023-01-01T00:00:00Z").
+			WithTag("v1.0")
 
 		expected := []string{
 			"apko", "build",
@@ -163,6 +164,7 @@ func TestApkoBuilder(t *testing.T) {
 			"--no-network",
 			"--repository-append", "https://example.com/repo",
 			"--timestamp", "2023-01-01T00:00:00Z",
+			"--tag", "v1.0",
 			"config.yaml",
 			"my-image:latest",
 			"image.tar",
@@ -175,7 +177,7 @@ func TestApkoBuilder(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(cmd, expected) {
-			t.Errorf("BuildCommand did not return expected command. Got: %v, Want: %v", cmd, expected)
+			t.Errorf("BuildCommand did not return expected command.\nGot:  %v\nWant: %v", cmd, expected)
 		}
 	})
 
@@ -280,4 +282,20 @@ func TestApkoBuilder_WithKeyRingAlpine(t *testing.T) {
 	if len(builder.keyringPaths) != 1 || builder.keyringPaths[0] != expectedKeyPath {
 		t.Errorf("Expected Alpine keyring path %s, but got %v", expectedKeyPath, builder.keyringPaths)
 	}
+}
+
+func TestApkoBuilder_WithTag(t *testing.T) {
+	t.Run("WithSpecificTag", func(t *testing.T) {
+		builder := NewApkoBuilder().WithTag("v1.0")
+		if !reflect.DeepEqual(builder.tags, []string{"v1.0"}) {
+			t.Errorf("Tag not set correctly, got %v", builder.tags)
+		}
+	})
+
+	t.Run("WithDefaultTag", func(t *testing.T) {
+		builder := NewApkoBuilder().WithTag()
+		if !reflect.DeepEqual(builder.tags, []string{"latest"}) {
+			t.Errorf("Default tag not set correctly, got %v", builder.tags)
+		}
+	})
 }

--- a/pkg/builderx/apko_test.go
+++ b/pkg/builderx/apko_test.go
@@ -3,6 +3,8 @@ package builderx
 import (
 	"reflect"
 	"testing"
+
+	"github.com/Excoriate/daggerx/pkg/fixtures"
 )
 
 func TestApkoBuilder(t *testing.T) {
@@ -247,12 +249,23 @@ func TestGetKeyringInfoForPreset(t *testing.T) {
 }
 
 func TestGetCacheDir(t *testing.T) {
-	mntPrefix := "/mnt"
-	expected := "/mnt/var/cache/apko"
-	result := GetCacheDir(mntPrefix)
-	if result != expected {
-		t.Errorf("Expected cache dir %s, got %s", expected, result)
-	}
+	t.Run("WithCustomMntPrefix", func(t *testing.T) {
+		mntPrefix := "/mnt"
+		expected := "/mnt/var/cache/apko"
+		result := GetCacheDir(mntPrefix)
+		if result != expected {
+			t.Errorf("Expected cache dir %s, got %s", expected, result)
+		}
+	})
+
+	t.Run("WithEmptyMntPrefix", func(t *testing.T) {
+		mntPrefix := ""
+		expected := fixtures.MntPrefix + "/var/cache/apko"
+		result := GetCacheDir(mntPrefix)
+		if result != expected {
+			t.Errorf("Expected cache dir %s, got %s", expected, result)
+		}
+	})
 }
 
 func TestGetOutputTarPath(t *testing.T) {


### PR DESCRIPTION
This commit adds a new method `WithTag` to the `ApkoBuilder` struct, which allows users to set a tag for the APKO build. If no tag is provided, it defaults to "latest".

The changes include:

- Adding the `tags` field to the `ApkoBuilder` struct to store the tags.
- Implementing the `WithTag` method to set the tags.
- Updating the `BuildCommand` method to include the `--tag` flag with the specified tag(s).
- Adding unit tests to verify the functionality of the `WithTag` method.

These changes provide more flexibility for users to customize the APKO build process and specify the desired tag for the output image.