### PR TITLE
feat: Add YAML validation utilities in the filex package

### DIFF
--- a/pkg/filex/yaml.go
+++ b/pkg/filex/yaml.go
@@ -1,0 +1,105 @@
+package filex
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ValidateYAMLExtension checks if the given file has a .yaml or .yml extension.
+// It returns true if the file has a valid YAML extension, otherwise false.
+//
+// Example usage:
+//
+//	valid := ValidateYAMLExtension("config.yaml")
+//	fmt.Println(valid) // Output: true
+func ValidateYAMLExtension(filename string) bool {
+	ext := filepath.Ext(filename)
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// ValidateYAMLExists checks if the given YAML file exists.
+// It returns true if the file exists, otherwise false.
+//
+// Example usage:
+//
+//	exists := ValidateYAMLExists("config.yaml")
+//	fmt.Println(exists) // Output: true
+func ValidateYAMLExists(filename string) bool {
+	_, err := os.Stat(filename)
+	return err == nil
+}
+
+// ValidateYAMLHasContent checks if the given YAML file is not empty.
+// It returns a boolean indicating whether the file has content and an error if any occurred during reading the file.
+//
+// Example usage:
+//
+//	hasContent, err := ValidateYAMLHasContent("config.yaml")
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+//	fmt.Println(hasContent) // Output: true
+func ValidateYAMLHasContent(filename string) (bool, error) {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return false, err
+	}
+	return len(content) > 0, nil
+}
+
+// ValidateYAMLStructure checks if the given YAML file can be properly unmarshaled into the provided struct.
+// It returns an error if the file cannot be read or if the content cannot be unmarshaled into the provided struct.
+//
+// Example usage:
+//
+//	var config Config
+//	err := ValidateYAMLStructure("config.yaml", &config)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func ValidateYAMLStructure(filename string, out interface{}) error {
+	content, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(content, out)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateYAML performs all YAML validations: extension, existence, content, and structure.
+// It returns an error if any of the validations fail.
+//
+// Example usage:
+//
+//	var config Config
+//	err := ValidateYAML("config.yaml", &config)
+//	if err != nil {
+//	    log.Fatal(err)
+//	}
+func ValidateYAML(filename string, out interface{}) error {
+	if !ValidateYAMLExtension(filename) {
+		return errors.New("invalid YAML file extension")
+	}
+
+	if !ValidateYAMLExists(filename) {
+		return errors.New("YAML file does not exist")
+	}
+
+	hasContent, err := ValidateYAMLHasContent(filename)
+	if err != nil {
+		return err
+	}
+	if !hasContent {
+		return errors.New("YAML file is empty")
+	}
+
+	return ValidateYAMLStructure(filename, out)
+}

--- a/pkg/filex/yaml_test.go
+++ b/pkg/filex/yaml_test.go
@@ -1,0 +1,194 @@
+package filex
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func TestValidateYAMLExtension(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{"Valid YAML", "test.yaml", true},
+		{"Valid YML", "test.yml", true},
+		{"Invalid extension", "test.txt", false},
+		{"No extension", "test", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateYAMLExtension(tt.filename); got != tt.want {
+				t.Errorf("ValidateYAMLExtension() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateYAMLExists(t *testing.T) {
+	// Create a temporary YAML file
+	tmpfile, err := os.CreateTemp("", "test*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpfile.Name())
+
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+	}{
+		{"Existing file", tmpfile.Name(), true},
+		{"Non-existing file", "non_existing.yaml", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ValidateYAMLExists(tt.filename); got != tt.want {
+				t.Errorf("ValidateYAMLExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateYAMLHasContent(t *testing.T) {
+	// Create temporary files
+	emptyFile, err := ioutil.TempFile("", "empty*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(emptyFile.Name())
+
+	contentFile, err := os.CreateTemp("", "content*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(contentFile.Name())
+
+	// Write content to the non-empty file
+	if _, err := contentFile.Write([]byte("key: value")); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+		want     bool
+		wantErr  bool
+	}{
+		{"Empty file", emptyFile.Name(), false, false},
+		{"File with content", contentFile.Name(), true, false},
+		{"Non-existing file", "non_existing.yaml", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateYAMLHasContent(tt.filename)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateYAMLHasContent() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ValidateYAMLHasContent() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateYAMLStructure(t *testing.T) {
+	type TestStruct struct {
+		Key string `yaml:"key"`
+	}
+
+	// Create temporary files
+	validFile, err := os.CreateTemp("", "valid*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(validFile.Name())
+
+	invalidFile, err := os.CreateTemp("", "invalid*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(invalidFile.Name())
+
+	// Write content to the files
+	if _, err := validFile.Write([]byte("key: value")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := invalidFile.Write([]byte("invalid: - yaml: content")); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+		out      interface{}
+		wantErr  bool
+	}{
+		{"Valid YAML", validFile.Name(), &TestStruct{}, false},
+		{"Invalid YAML", invalidFile.Name(), &TestStruct{}, true},
+		{"Non-existing file", "non_existing.yaml", &TestStruct{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateYAMLStructure(tt.filename, tt.out); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateYAMLStructure() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateYAML(t *testing.T) {
+	type TestStruct struct {
+		Key string `yaml:"key"`
+	}
+
+	// Create temporary files
+	validFile, err := os.CreateTemp("", "valid*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(validFile.Name())
+
+	invalidExtFile, err := os.CreateTemp("", "invalid*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(invalidExtFile.Name())
+
+	emptyFile, err := os.CreateTemp("", "empty*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(emptyFile.Name())
+
+	// Write content to the valid file
+	if _, err := validFile.Write([]byte("key: value")); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		filename string
+		out      interface{}
+		wantErr  bool
+	}{
+		{"Valid YAML", validFile.Name(), &TestStruct{}, false},
+		{"Invalid extension", invalidExtFile.Name(), &TestStruct{}, true},
+		{"Empty file", emptyFile.Name(), &TestStruct{}, true},
+		{"Non-existing file", "non_existing.yaml", &TestStruct{}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateYAML(tt.filename, tt.out); (err != nil) != tt.wantErr {
+				t.Errorf("ValidateYAML() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit introduces a set of YAML validation utilities in the `filex` package. The new functions provide the following capabilities:

- `ValidateYAMLExtension`: Checks if the given file has a valid YAML extension (.yaml or .yml).
- `ValidateYAMLExists`: Checks if the given YAML file exists.
- `ValidateYAMLHasContent`: Checks if the given YAML file is not empty.
- `ValidateYAMLStructure`: Checks if the given YAML file can be properly unmarshaled into the provided struct.
- `ValidateYAML`: Performs all the above YAML validations.

These utilities can be used to ensure the integrity and correctness of YAML configuration files before processing them in the application.