### PR TITLE
feat: Add configurable install directory to BaseInstaller

### DIFF
--- a/pkg/installerx/opentofu.go
+++ b/pkg/installerx/opentofu.go
@@ -23,7 +23,7 @@ type OpenTofuInstaller struct {
 //   - *OpenTofuInstaller: A pointer to the newly created OpenTofuInstaller.
 func NewOpenTofuInstaller(version string) *OpenTofuInstaller {
 	return &OpenTofuInstaller{
-		BaseInstaller: NewBaseInstaller(version, openTofuReleaseURL, "tofu", "zip"),
+		BaseInstaller: NewBaseInstaller(version, openTofuReleaseURL, "tofu", "zip", "/app/bin"),
 	}
 }
 

--- a/pkg/installerx/terraform.go
+++ b/pkg/installerx/terraform.go
@@ -21,7 +21,7 @@ type TerraformInstaller struct {
 //   - *TerraformInstaller: A pointer to the newly created TerraformInstaller
 func NewTerraformInstaller(version string) *TerraformInstaller {
 	return &TerraformInstaller{
-		BaseInstaller: NewBaseInstaller(version, terraformReleaseURL, "terraform", "zip"),
+		BaseInstaller: NewBaseInstaller(version, terraformReleaseURL, "terraform", "zip", "/app/bin"),
 	}
 }
 

--- a/pkg/installerx/terragrunt.go
+++ b/pkg/installerx/terragrunt.go
@@ -24,7 +24,7 @@ type TerragruntInstaller struct {
 //   - *TerragruntInstaller: A pointer to the newly created TerragruntInstaller.
 func NewTerragruntInstaller(version string) *TerragruntInstaller {
 	return &TerragruntInstaller{
-		BaseInstaller: NewBaseInstaller(version, terragruntReleaseURL, "terragrunt", ""),
+		BaseInstaller: NewBaseInstaller(version, terragruntReleaseURL, "terragrunt", "", "/app/bin"),
 	}
 }
 


### PR DESCRIPTION
- Add an `installDir` field to the `BaseInstaller` struct
- Update the `NewBaseInstaller` function to set the `installDir` field with a default value of `/app/bin` if not provided
- Update the `GetInstallCommands` method to use the `installDir` field instead of hardcoding `/usr/local/bin`
- Update the `Install` method to append the `installDir` to the `PATH` environment variable

This change allows the installation directory to be configured for each installer, making the installers more flexible and easier to use in different environments.