### PR TITLE
feat: Update binary installation directory to $HOME/bin

### DIFF
--- a/pkg/installerx/base_installer.go
+++ b/pkg/installerx/base_installer.go
@@ -2,7 +2,6 @@
 package installerx
 
 import (
-	"fmt"
 	"strings"
 
 	"dagger.io/dagger"
@@ -21,7 +20,7 @@ type BaseInstaller struct {
 // NewBaseInstaller creates a new BaseInstaller instance.
 func NewBaseInstaller(version, releaseURL, binaryName, fileExt, installDir string) *BaseInstaller {
 	if installDir == "" {
-		installDir = "/app/bin"
+		installDir = "$HOME/bin"
 	}
 	return &BaseInstaller{
 		version:    strings.TrimPrefix(version, "v"),
@@ -35,17 +34,17 @@ func NewBaseInstaller(version, releaseURL, binaryName, fileExt, installDir strin
 // GetInstallCommands returns the commands to install the binary.
 func (bi *BaseInstaller) GetInstallCommands(url string) [][]string {
 	commands := [][]string{
-		{"mkdir", "-p", bi.installDir},
+		{"mkdir", "-p", "$HOME/bin"},
 		{"curl", "-L", "-o", "/tmp/" + bi.binaryName + "." + bi.fileExt, url},
 	}
 	if bi.fileExt == "zip" {
-		commands = append(commands, []string{"unzip", "-d", bi.installDir, "/tmp/" + bi.binaryName + "." + bi.fileExt})
+		commands = append(commands, []string{"unzip", "-d", "$HOME/bin", "/tmp/" + bi.binaryName + "." + bi.fileExt})
 	} else {
-		commands = append(commands, []string{"mv", "/tmp/" + bi.binaryName + "." + bi.fileExt, bi.installDir + "/" + bi.binaryName})
+		commands = append(commands, []string{"mv", "/tmp/" + bi.binaryName + "." + bi.fileExt, "$HOME/bin/" + bi.binaryName})
 	}
 	commands = append(commands,
-		[]string{"chmod", "+x", bi.installDir + "/" + bi.binaryName},
-		[]string{bi.installDir + "/" + bi.binaryName, "--version"},
+		[]string{"chmod", "+x", "$HOME/bin/" + bi.binaryName},
+		[]string{"$HOME/bin/" + bi.binaryName, "--version"},
 	)
 	if bi.fileExt == "zip" {
 		commands = append(commands, []string{"rm", "/tmp/" + bi.binaryName + "." + bi.fileExt})
@@ -58,11 +57,5 @@ func (bi *BaseInstaller) Install(container *dagger.Container, commands [][]strin
 	for _, cmd := range commands {
 		container = container.WithExec(cmd)
 	}
-	return container.WithEnvVariable("PATH", bi.installDir+":$PATH")
-}
-
-// GetLatestVersion returns the latest version of the binary.
-func (bi *BaseInstaller) GetLatestVersion() (string, error) {
-	// Default implementation, should be overridden by specific installers
-	return "", fmt.Errorf("GetLatestVersion not implemented for BaseInstaller")
+	return container.WithEnvVariable("PATH", "$HOME/bin:$PATH")
 }

--- a/pkg/installerx/opentofu.go
+++ b/pkg/installerx/opentofu.go
@@ -23,7 +23,7 @@ type OpenTofuInstaller struct {
 //   - *OpenTofuInstaller: A pointer to the newly created OpenTofuInstaller.
 func NewOpenTofuInstaller(version string) *OpenTofuInstaller {
 	return &OpenTofuInstaller{
-		BaseInstaller: NewBaseInstaller(version, openTofuReleaseURL, "tofu", "zip", "/app/bin"),
+		BaseInstaller: NewBaseInstaller(version, openTofuReleaseURL, "tofu", "zip", "$HOME/bin"),
 	}
 }
 

--- a/pkg/installerx/terraform.go
+++ b/pkg/installerx/terraform.go
@@ -21,7 +21,7 @@ type TerraformInstaller struct {
 //   - *TerraformInstaller: A pointer to the newly created TerraformInstaller
 func NewTerraformInstaller(version string) *TerraformInstaller {
 	return &TerraformInstaller{
-		BaseInstaller: NewBaseInstaller(version, terraformReleaseURL, "terraform", "zip", "/app/bin"),
+		BaseInstaller: NewBaseInstaller(version, terraformReleaseURL, "terraform", "zip", "$HOME/bin"),
 	}
 }
 

--- a/pkg/installerx/terragrunt.go
+++ b/pkg/installerx/terragrunt.go
@@ -24,7 +24,7 @@ type TerragruntInstaller struct {
 //   - *TerragruntInstaller: A pointer to the newly created TerragruntInstaller.
 func NewTerragruntInstaller(version string) *TerragruntInstaller {
 	return &TerragruntInstaller{
-		BaseInstaller: NewBaseInstaller(version, terragruntReleaseURL, "terragrunt", "", "/app/bin"),
+		BaseInstaller: NewBaseInstaller(version, terragruntReleaseURL, "terragrunt", "", "$HOME/bin"),
 	}
 }
 


### PR DESCRIPTION
 
The changes in this commit update the default installation directory for the various binary installers from `/app/bin` to `$HOME/bin`. This change ensures that the installed binaries are accessible to the user's environment, regardless of the specific container or platform being used.

Key changes:
- Updated the `NewBaseInstaller` function to use `$HOME/bin` as the default installation directory if none is provided.
- Updated the `NewTerraformInstaller`, `NewOpenTofuInstaller`, and `NewTerragruntInstaller` functions to use `$HOME/bin` as the installation directory.
- Updated the `GetInstallCommands` method of `BaseInstaller` to use `$HOME/bin` for the installation and cleanup steps.
- Removed the `GetLatestVersion` method from `BaseInstaller` as it was not implemented.