### PR TITLE
fix: Update Terraform and OpenTofu installation commands

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/oauth2 v0.20.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -80,5 +81,4 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240515191416-fc5f0ca64291 // indirect
 	google.golang.org/grpc v1.64.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/installerx/constants.go
+++ b/pkg/installerx/constants.go
@@ -1,0 +1,6 @@
+package installerx
+
+const (
+	// DefaultInstallDir is the default directory for installing binaries
+	DefaultInstallDir = "/usr/local/bin"
+)

--- a/pkg/installerx/opentofu.go
+++ b/pkg/installerx/opentofu.go
@@ -3,48 +3,41 @@ package installerx
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // OpenTofuInstallParams represents the parameters for installing OpenTofu
 type OpenTofuInstallParams struct {
 	// Version of OpenTofu to install (e.g., "1.6.0")
 	Version string
-	// EntryPoint for the command. If empty, defaults to "sh -c"
-	EntryPoint string
-	// InstallDir is the directory to install OpenTofu. If empty, defaults to "/usr/local/bin"
+	// InstallDir is the directory to install OpenTofu. If empty, defaults to DefaultInstallDir
 	InstallDir string
 }
 
-// GetOpenTofuInstallCommand returns a slice of strings representing the command
+// GetOpenTofuInstallCommand returns a string representing the command
 // to install OpenTofu of a specific version.
 //
 // Parameters:
 // - params: OpenTofuInstallParams struct containing installation parameters
 //
 // Returns:
-// - A slice of strings representing the installation command
-func GetOpenTofuInstallCommand(params OpenTofuInstallParams) []string {
-	if params.EntryPoint == "" {
-		params.EntryPoint = "sh -c"
-	}
-
+// - A string representing the installation command
+func GetOpenTofuInstallCommand(params OpenTofuInstallParams) string {
 	if params.InstallDir == "" {
-		params.InstallDir = "/usr/local/bin"
+		params.InstallDir = DefaultInstallDir
 	}
 
 	installPath := filepath.Join(params.InstallDir, "opentofu")
 
-	command := fmt.Sprintf(`
-set -ex
+	command := fmt.Sprintf(`set -ex
 echo "Downloading OpenTofu..."
-curl -L https://github.com/opentofu/opentofu/releases/download/v%[1]s/tofu_%[1]s_linux_amd64.zip -o /tmp/opentofu.zip
-unzip /tmp/opentofu.zip -d %[2]s
-mv %[2]s/tofu %[3]s
-chmod +x %[3]s
+curl -L "https://github.com/opentofu/opentofu/releases/download/v%[1]s/tofu_%[1]s_linux_amd64.zip" -o /tmp/opentofu.zip
+unzip /tmp/opentofu.zip -d /tmp
+mv /tmp/tofu %[2]s
+chmod +x %[2]s
 rm /tmp/opentofu.zip
 echo "OpenTofu installation completed successfully"
-%[3]s version
-`, params.Version, params.InstallDir, installPath)
+%[2]s version`, params.Version, installPath)
 
-	return []string{params.EntryPoint, command}
+	return strings.TrimSpace(command)
 }

--- a/pkg/installerx/opentofu_test.go
+++ b/pkg/installerx/opentofu_test.go
@@ -1,7 +1,6 @@
 package installerx
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -9,49 +8,45 @@ func TestGetOpenTofuInstallCommand(t *testing.T) {
 	tests := []struct {
 		name   string
 		params OpenTofuInstallParams
-		want   []string
+		want   string
 	}{
 		{
 			name: "Default parameters",
 			params: OpenTofuInstallParams{
 				Version: "1.6.0",
 			},
-			want: []string{"sh -c", `
-set -ex
+			want: `set -ex
 echo "Downloading OpenTofu..."
-curl -L https://github.com/opentofu/opentofu/releases/download/v1.6.0/tofu_1.6.0_linux_amd64.zip -o /tmp/opentofu.zip
-unzip /tmp/opentofu.zip -d /usr/local/bin
-mv /usr/local/bin/tofu /usr/local/bin/opentofu
+curl -L "https://github.com/opentofu/opentofu/releases/download/v1.6.0/tofu_1.6.0_linux_amd64.zip" -o /tmp/opentofu.zip
+unzip /tmp/opentofu.zip -d /tmp
+mv /tmp/tofu /usr/local/bin/opentofu
 chmod +x /usr/local/bin/opentofu
 rm /tmp/opentofu.zip
 echo "OpenTofu installation completed successfully"
-/usr/local/bin/opentofu version
-`},
+/usr/local/bin/opentofu version`,
 		},
 		{
-			name: "Custom entry point and install directory",
+			name: "Custom install directory",
 			params: OpenTofuInstallParams{
 				Version:    "1.7.0",
-				EntryPoint: "bash -c",
 				InstallDir: "/custom/bin",
 			},
-			want: []string{"bash -c", `
-set -ex
+			want: `set -ex
 echo "Downloading OpenTofu..."
-curl -L https://github.com/opentofu/opentofu/releases/download/v1.7.0/tofu_1.7.0_linux_amd64.zip -o /tmp/opentofu.zip
-unzip /tmp/opentofu.zip -d /custom/bin
-mv /custom/bin/tofu /custom/bin/opentofu
+curl -L "https://github.com/opentofu/opentofu/releases/download/v1.7.0/tofu_1.7.0_linux_amd64.zip" -o /tmp/opentofu.zip
+unzip /tmp/opentofu.zip -d /tmp
+mv /tmp/tofu /custom/bin/opentofu
 chmod +x /custom/bin/opentofu
 rm /tmp/opentofu.zip
 echo "OpenTofu installation completed successfully"
-/custom/bin/opentofu version
-`},
+/custom/bin/opentofu version`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetOpenTofuInstallCommand(tt.params); !reflect.DeepEqual(got, tt.want) {
+			got := GetOpenTofuInstallCommand(tt.params)
+			if got != tt.want {
 				t.Errorf("GetOpenTofuInstallCommand() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/installerx/terraform.go
+++ b/pkg/installerx/terraform.go
@@ -3,44 +3,38 @@ package installerx
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // TerraformInstallParams represents the parameters for installing Terraform
 type TerraformInstallParams struct {
 	// Version of Terraform to install (e.g., "1.0.0")
 	Version string
-	// EntryPoint for the command. If empty, defaults to "sh -c"
-	EntryPoint string
-	// InstallDir is the directory to install Terraform. If empty, defaults to "/usr/local/bin"
+	// InstallDir is the directory to install Terraform. If empty, defaults to DefaultInstallDir
 	InstallDir string
 }
 
-// GetTerraformInstallCommand returns a slice of strings representing the command
+// GetTerraformInstallCommand returns a string representing the command
 // to install Terraform of a specific version.
 //
 // Parameters:
 // - params: TerraformInstallParams struct containing installation parameters
 //
 // Returns:
-// - A slice of strings representing the installation command
-func GetTerraformInstallCommand(params TerraformInstallParams) []string {
-	if params.EntryPoint == "" {
-		params.EntryPoint = "sh -c"
-	}
-
+// - A string representing the installation command
+func GetTerraformInstallCommand(params TerraformInstallParams) string {
 	if params.InstallDir == "" {
-		params.InstallDir = "/usr/local/bin"
+		params.InstallDir = DefaultInstallDir
 	}
 
 	installPath := filepath.Join(params.InstallDir, "terraform")
 
-	command := fmt.Sprintf(`
-set -ex
+	command := fmt.Sprintf(`set -ex
 curl -L https://releases.hashicorp.com/terraform/%[1]s/terraform_%[1]s_linux_amd64.zip -o /tmp/terraform.zip
-unzip /tmp/terraform.zip -d %[2]s
-chmod +x %[3]s
-rm /tmp/terraform.zip
-`, params.Version, params.InstallDir, installPath)
+unzip /tmp/terraform.zip -d /tmp
+mv /tmp/terraform %[2]s
+chmod +x %[2]s
+rm /tmp/terraform.zip`, params.Version, installPath)
 
-	return []string{params.EntryPoint, command}
+	return strings.TrimSpace(command)
 }

--- a/pkg/installerx/terraform_test.go
+++ b/pkg/installerx/terraform_test.go
@@ -1,7 +1,6 @@
 package installerx
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -9,41 +8,39 @@ func TestGetTerraformInstallCommand(t *testing.T) {
 	tests := []struct {
 		name   string
 		params TerraformInstallParams
-		want   []string
+		want   string
 	}{
 		{
 			name: "Default parameters",
 			params: TerraformInstallParams{
 				Version: "1.0.0",
 			},
-			want: []string{"sh -c", `
-set -ex
+			want: `set -ex
 curl -L https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_linux_amd64.zip -o /tmp/terraform.zip
-unzip /tmp/terraform.zip -d /usr/local/bin
+unzip /tmp/terraform.zip -d /tmp
+mv /tmp/terraform /usr/local/bin/terraform
 chmod +x /usr/local/bin/terraform
-rm /tmp/terraform.zip
-`},
+rm /tmp/terraform.zip`,
 		},
 		{
-			name: "Custom entry point and install directory",
+			name: "Custom install directory",
 			params: TerraformInstallParams{
 				Version:    "1.1.0",
-				EntryPoint: "bash -c",
 				InstallDir: "/custom/bin",
 			},
-			want: []string{"bash -c", `
-set -ex
+			want: `set -ex
 curl -L https://releases.hashicorp.com/terraform/1.1.0/terraform_1.1.0_linux_amd64.zip -o /tmp/terraform.zip
-unzip /tmp/terraform.zip -d /custom/bin
+unzip /tmp/terraform.zip -d /tmp
+mv /tmp/terraform /custom/bin/terraform
 chmod +x /custom/bin/terraform
-rm /tmp/terraform.zip
-`},
+rm /tmp/terraform.zip`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetTerraformInstallCommand(tt.params); !reflect.DeepEqual(got, tt.want) {
+			got := GetTerraformInstallCommand(tt.params)
+			if got != tt.want {
 				t.Errorf("GetTerraformInstallCommand() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/installerx/terragrunt.go
+++ b/pkg/installerx/terragrunt.go
@@ -3,42 +3,35 @@ package installerx
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 )
 
 // TerragruntInstallParams represents the parameters for installing Terragrunt
 type TerragruntInstallParams struct {
 	// Version of Terragrunt to install (e.g., "0.38.0")
 	Version string
-	// EntryPoint for the command. If empty, defaults to "sh -c"
-	EntryPoint string
 	// InstallDir is the directory to install Terragrunt. If empty, defaults to "/usr/local/bin"
 	InstallDir string
 }
 
-// GetTerragruntInstallCommand returns a slice of strings representing the command
+// GetTerragruntInstallCommand returns a string representing the command
 // to install Terragrunt of a specific version.
 //
 // Parameters:
 // - params: TerragruntInstallParams struct containing installation parameters
 //
 // Returns:
-// - A slice of strings representing the installation command
-func GetTerragruntInstallCommand(params TerragruntInstallParams) []string {
-	if params.EntryPoint == "" {
-		params.EntryPoint = "sh -c"
-	}
-
+// - A string representing the installation command
+func GetTerragruntInstallCommand(params TerragruntInstallParams) string {
 	if params.InstallDir == "" {
 		params.InstallDir = "/usr/local/bin"
 	}
 
 	installPath := filepath.Join(params.InstallDir, "terragrunt")
 
-	command := fmt.Sprintf(`
-set -ex
-curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v%[1]s/terragrunt_linux_amd64 -o %[2]s
-chmod +x %[2]s
-`, params.Version, installPath)
+	command := fmt.Sprintf(`set -ex
+curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v%s/terragrunt_linux_amd64 -o %s
+chmod +x %s`, params.Version, installPath, installPath)
 
-	return []string{params.EntryPoint, command}
+	return strings.TrimSpace(command)
 }

--- a/pkg/installerx/terragrunt_test.go
+++ b/pkg/installerx/terragrunt_test.go
@@ -1,7 +1,6 @@
 package installerx
 
 import (
-	"reflect"
 	"testing"
 )
 
@@ -9,37 +8,33 @@ func TestGetTerragruntInstallCommand(t *testing.T) {
 	tests := []struct {
 		name   string
 		params TerragruntInstallParams
-		want   []string
+		want   string
 	}{
 		{
 			name: "Default parameters",
 			params: TerragruntInstallParams{
 				Version: "0.38.0",
 			},
-			want: []string{"sh -c", `
-set -ex
+			want: `set -ex
 curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v0.38.0/terragrunt_linux_amd64 -o /usr/local/bin/terragrunt
-chmod +x /usr/local/bin/terragrunt
-`},
+chmod +x /usr/local/bin/terragrunt`,
 		},
 		{
-			name: "Custom entry point and install directory",
+			name: "Custom install directory",
 			params: TerragruntInstallParams{
 				Version:    "0.39.0",
-				EntryPoint: "bash -c",
 				InstallDir: "/custom/bin",
 			},
-			want: []string{"bash -c", `
-set -ex
+			want: `set -ex
 curl -L https://github.com/gruntwork-io/terragrunt/releases/download/v0.39.0/terragrunt_linux_amd64 -o /custom/bin/terragrunt
-chmod +x /custom/bin/terragrunt
-`},
+chmod +x /custom/bin/terragrunt`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetTerragruntInstallCommand(tt.params); !reflect.DeepEqual(got, tt.want) {
+			got := GetTerragruntInstallCommand(tt.params)
+			if got != tt.want {
 				t.Errorf("GetTerragruntInstallCommand() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
The changes focus on the following:

1. Simplify the Terraform installation command by removing the unnecessary `entryPoint` parameter and using a more concise command.
2. Simplify the OpenTofu installation command by removing the unnecessary `entryPoint` parameter and using a more concise command.
3. Remove the unused `gopkg.in/yaml.v3` dependency from the `go.mod` file.

feat: Improve user experience with a new feature - Add a new button and update styles