### PR TITLE
feat: Add function to generate AWS CLI installation command

### DIFF
--- a/pkg/installerx/awscli.go
+++ b/pkg/installerx/awscli.go
@@ -1,0 +1,38 @@
+package installerx
+
+import (
+	"fmt"
+	"strings"
+)
+
+// GetAwsCliInstallCommand generates a shell command to download and install the AWS CLI
+// for the specified architecture. If the architecture is not provided, it defaults to "x86_64".
+// The function also handles the conversion of "aarch64" to "arm64" for compatibility.
+//
+// Parameters:
+//
+//	architecture - a string representing the system architecture (e.g., "x86_64", "aarch64")
+//
+// Returns:
+//
+//	A string containing the shell command to install the AWS CLI.
+func GetAwsCliInstallCommand(architecture string) string {
+	if architecture == "" {
+		architecture = "x86_64"
+	}
+
+	if architecture == "aarch64" {
+		architecture = "arm64"
+	}
+
+	url := fmt.Sprintf("https://awscli.amazonaws.com/awscli-exe-linux-%s.zip", architecture)
+
+	command := fmt.Sprintf(`set -ex
+curl -L %[1]s -o awscliv2.zip
+unzip awscliv2.zip
+sudo ./aws/install
+rm -rf awscliv2.zip aws
+`, url)
+
+	return strings.TrimSpace(command)
+}

--- a/pkg/installerx/awscli_test.go
+++ b/pkg/installerx/awscli_test.go
@@ -1,0 +1,49 @@
+package installerx
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetAwsCliInstallCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		architecture string
+		wantContains []string
+	}{
+		{
+			name:         "Default architecture",
+			architecture: "",
+			wantContains: []string{"https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"},
+		},
+		{
+			name:         "x86_64 architecture",
+			architecture: "x86_64",
+			wantContains: []string{"https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"},
+		},
+		{
+			name:         "aarch64 architecture",
+			architecture: "aarch64",
+			wantContains: []string{"https://awscli.amazonaws.com/awscli-exe-linux-arm64.zip"},
+		},
+		{
+			name:         "arm64 architecture",
+			architecture: "arm64",
+			wantContains: []string{"https://awscli.amazonaws.com/awscli-exe-linux-arm64.zip"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetAwsCliInstallCommand(tt.architecture)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("GetAwsCliInstallCommand() = %v, want to contain %v", got, want)
+				}
+			}
+			if !strings.Contains(got, "curl -L") || !strings.Contains(got, "unzip awscliv2.zip") {
+				t.Errorf("GetAwsCliInstallCommand() does not contain expected commands")
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds a new function `GetAwsCliInstallCommand` to the `installerx` package. The function generates a shell command to download and install the AWS CLI for a specified architecture. It handles the conversion of "aarch64" to "arm64" for compatibility. The function also includes test cases to validate the generated command for different architectures.