### PR TITLE
fix: Remove empty cmdbuilder package

### DIFF
--- a/pkg/cmdbuilder/args.go
+++ b/pkg/cmdbuilder/args.go
@@ -1,8 +1,0 @@
-// Package cmdbuilder provides utilities for building command-line arguments.
-package cmdbuilder
-
-// PlaceholderFunction is a temporary function to ensure the package is not empty.
-// TODO: Replace this with actual implementation.
-func PlaceholderFunction() {
-	// Placeholder implementation
-}


### PR DESCRIPTION
The `cmdbuilder` package was previously empty and contained only a placeholder function. This commit removes the entire package as it is no longer needed.