### PR TITLE
feat: Add validation for Apko keyring format

### DIFF
--- a/pkg/builderx/apko_validations.go
+++ b/pkg/builderx/apko_validations.go
@@ -1,0 +1,35 @@
+package builderx
+
+import (
+	"fmt"
+	"strings"
+)
+
+// IsKeyringFormatValid validates the format of the provided keyrings.
+// Each keyring should be in the format "filesystempath=URL", where:
+// - filesystempath is a relative path under "/etc/apk/keys/"
+// - URL is a valid URL
+// The function also takes an optional parameter enforceHTTPS which defaults to true.
+// If enforceHTTPS is true, the URL must start with "https://".
+func IsKeyringFormatValid(keyrings []string, enforceHTTPS ...bool) error {
+	httpsRequired := true
+	if len(enforceHTTPS) > 0 {
+		httpsRequired = enforceHTTPS[0]
+	}
+
+	for _, keyring := range keyrings {
+		parts := strings.Split(keyring, "=")
+		if len(parts) != 2 {
+			return fmt.Errorf("invalid keyring format: %s", keyring)
+		}
+		path := parts[0]
+		url := parts[1]
+		if !strings.HasPrefix(path, "/etc/apk/keys/") {
+			return fmt.Errorf("invalid keyring path: %s", path)
+		}
+		if httpsRequired && !strings.HasPrefix(url, "https://") {
+			return fmt.Errorf("invalid keyring URL: %s", url)
+		}
+	}
+	return nil
+}

--- a/pkg/builderx/apko_validations_test.go
+++ b/pkg/builderx/apko_validations_test.go
@@ -1,0 +1,74 @@
+package builderx
+
+import (
+	"testing"
+)
+
+func TestIsKeyringFormatValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		keyrings []string
+		wantErr  bool
+		errMsg   string
+	}{
+		{
+			name:     "Valid keyring",
+			keyrings: []string{"/etc/apk/keys/foo=https://example.com/key.pub"},
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid format - missing '='",
+			keyrings: []string{"/etc/apk/keys/foo"},
+			wantErr:  true,
+			errMsg:   "invalid keyring format: /etc/apk/keys/foo",
+		},
+		{
+			name:     "Invalid format - extra '='",
+			keyrings: []string{"/etc/apk/keys/foo=https://example.com/key.pub=extra"},
+			wantErr:  true,
+			errMsg:   "invalid keyring format: /etc/apk/keys/foo=https://example.com/key.pub=extra",
+		},
+		{
+			name:     "Invalid path",
+			keyrings: []string{"/wrong/path/foo=https://example.com/key.pub"},
+			wantErr:  true,
+			errMsg:   "invalid keyring path: /wrong/path/foo",
+		},
+		{
+			name:     "Invalid URL",
+			keyrings: []string{"/etc/apk/keys/foo=http://example.com/key.pub"},
+			wantErr:  true,
+			errMsg:   "invalid keyring URL: http://example.com/key.pub",
+		},
+		{
+			name: "Multiple keyrings with one invalid",
+			keyrings: []string{
+				"/etc/apk/keys/foo=https://example.com/key.pub",
+				"/etc/apk/keys/bar=http://example.com/key.pub",
+			},
+			wantErr: true,
+			errMsg:  "invalid keyring URL: http://example.com/key.pub",
+		},
+		{
+			name: "Multiple valid keyrings",
+			keyrings: []string{
+				"/etc/apk/keys/foo=https://example.com/key.pub",
+				"/etc/apk/keys/bar=https://example.com/key2.pub",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := IsKeyringFormatValid(tt.keyrings)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsKeyringFormatValid() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if err != nil && tt.errMsg != "" && err.Error() != tt.errMsg {
+				t.Errorf("IsKeyringFormatValid() error = %v, wantErrMsg %v", err.Error(), tt.errMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Implement the `IsKeyringFormatValid` function to validate the format of the provided keyrings. Each keyring should be in the format "filesystempath=URL", where:
- filesystempath is a relative path under "/etc/apk/keys/"
- URL is a valid URL
The function also takes an optional parameter `enforceHTTPS` which defaults to `true`. If `enforceHTTPS` is `true`, the URL must start with "https://".