### PR TITLE
feat: Improve apko builder options - Remove `WithOutputTarball` and update `WithArchitecture` usage

### DIFF
--- a/pkg/apkox/apko.go
+++ b/pkg/apkox/apko.go
@@ -358,7 +358,7 @@ func (b *ApkoBuilder) BuildCommand() ([]string, error) {
 	}
 
 	// Start with the base command and the three required arguments
-	cmd := []string{"apko", "build", b.configFile, b.outputImage, "image.tar"}
+	cmd := []string{"apko", "build", b.configFile, b.outputImage}
 
 	// Add optional arguments
 	if b.cacheDir != "" {


### PR DESCRIPTION
Here is the pull request description based on the provided context:

## 🎯 What
* ❓ The changes in this PR focus on improving the apko builder options by:
  - Removing the `WithOutputTarball` method, as the output tarball is no longer a required argument for the `apko build` command.
  - Updating the usage of `WithArchitecture` method to set the build architecture correctly, as the last specified architecture takes precedence.
* 🎉 These changes will provide a better user experience by simplifying the apko builder options and ensuring the build architecture is set correctly.

## 🤔 Why
* 💡 These changes were made to improve the usability and reliability of the apko builder.
* 🎯 The benefits include a more intuitive and straightforward builder API, as well as more consistent handling of the build architecture.

## 📚 References
* 🔗 This PR is related to the changes described in the commit messages.